### PR TITLE
Fix some typos and update some default configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ fluentbit_inputs:
 fluentbit_outputs:
   - name: file
     match: "*"
-    path: "/tmp/fbitoutput.txt"
+    path: "/tmp/"
 
 fluentbit_additional_conf_files: []
 

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -13,7 +13,7 @@
     dest: '/etc/td-agent-bit/{{ item.name }}'
     mode: 0644
   with_items: '{{ fluentbit_additional_conf_files }}'
-  when: fluentbit_additional_conf_files | lenght >0
+  when: fluentbit_additional_conf_files | length >0
   notify: Restart fluenbit service
 
 - name: Configure | Source additional td-agent-bit parsers conf


### PR DESCRIPTION
This commit fixes a typo in the tasks/configure.yml  file