### PR TITLE
2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
         image:
           - geerlingguy/docker-ubuntu2004-ansible:latest
           - geerlingguy/docker-centos7-ansible:latest
+          - geerlingguy/docker-ubuntu1804-ansible:latest
+          - geerlingguy/docker-rockylinux8-ansible:latest
+          - geerlingguy/docker-centos8-ansible:latest
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,7 @@ jobs:
       matrix:
         image:
           - geerlingguy/docker-ubuntu2004-ansible:latest
-          - geerlingguy/docker-centos7-ansible:latest
-          - geerlingguy/docker-ubuntu1804-ansible:latest
-          - geerlingguy/docker-rockylinux8-ansible:latest
-          - geerlingguy/docker-centos8-ansible:latest
+
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible==2.9 molecule[docker] docker pytest pytest-testinfra ansible-lint
+        run: pip3 install ansible molecule[docker] docker pytest pytest-testinfra ansible-lint
 
       - name: Run Molecule tests.
         run: molecule test

--- a/README.md
+++ b/README.md
@@ -3,12 +3,66 @@
 [![Build Status](https://github.com/wpnops/ansible-role-fluent-bit/workflows/CI/badge.svg)](https://github.com/wpnops/ansible-role-fluent-bit/actions)
 [![Ansible Galaxy](https://img.shields.io/badge/wpninfra.fluent__bit-role-blue.svg)](https://galaxy.ansible.com/wpninfra/fluent_bit/)
 
-An [ansible role](https://galaxy.ansible.com/wpninfra/fluent-bit) to install and configure fluent-bit
+An [ansible role](https://galaxy.ansible.com/wpninfra/fluent-bit) to install and configure fluent-bit.
+
+Please refer to [fluentbit's documentation](https://docs.fluentbit.io/manual/) for tool specific configuration.
 
 ## Role Variables
 
-Please refer to the [defaults file](/defaults/main.yml) for an up to date list of input parameters.
+| Name                              | Description                                                                                                           | Required | Default |
+|-----------------------------------|-----------------------------------------------------------------------------------------------------------------------|----------|---------|
+| fluentbit_svc.flush_seconds       | Fluentbit service flush time in seconds                                                                               | yes      | 5       |
+| fluentbit_svc.daemon              | Boolean value to set if Fluent Bit should run as a Daemon (background) or not.                                        | yes      | false   |
+| fluentbit_svc.log_level           | Set the logging verbosity level. Allowed values are: error, warn, info, debug and trace.                              | yes      | info    |
+| fluentbit_svc.log_file            | Absolute path for an optional log file.  By default all logs are redirected to the standard error interface (stderr). | no       |         |
+| fluentbit_svc.custom_parsers_file | Path for a parsers configuration file                                                                                 | no       |         |
+| fluentbit_svc.custom_plugins_file | Path for a plugins configuration file                                                                                 | no       |         |
+| fluentbit_svc.streams_file        | Path for the Stream Processor configuration file.                                                                     | no       |         |
+| fluentbit_filters                 | Dictionary with fluentbit filters                                                                                     | no       |         |
+| fluentbit_inputs                  | Dictionary with fluentbit inputs                                                                                      | no       |         |
+| fluentbit_outputs                 | Dictionary with fluentbit outputs                                                                                     | no       |         |
+| fluentbit_parsers                 | Dictionary with fluentbit custom written parsers                                                                      | no       |         |
 
+**IF NO INPUTS OR OUTPUTS ARE DEFINED FLUENTBIT WILL INITIALIZE WITH THE FOLLOWING LOGGING STRUCTURE**
+```
+[INPUT]
+  Name cpu
+  Tag cpu_default
+
+[OUTPUT]
+  Name file
+  Match cpu_default
+  Path /dev/null
+```
+**EXAMPLE DICTIONARY BASED CONFIGURATION**
+```
+fluentbit_inputs:
+  - name: cpu
+    tag: cpu_default
+
+fluentbit_outputs:
+  - name: file
+    match: cpu_default
+    path: /dev/null
+```
+**IN CASE IT IS REQUIRED TO HAVE TOW KEYS WITH THE SAME NAME IN A CONFIGURATION DICTIONARY IT CAN BE SPECIFIED USING THE FOLLOWING FORMAT**
+<br>
+For example:
+```
+fluentbit_filters:
+  - name: record_modifier
+    match: '*'
+    0__record: hostname ${HOSTNAME}
+    1__record: product something
+```
+Will result in:
+```
+[FILTER]
+  name record_modifier
+  match *
+  record hostname ${HOSTNAME}
+  record product something
+```
 ## Dependencies
 
 By default this role does not depend on any external roles. If any such dependency is required please [add them](/meta/main.yml) according to [the documentation](http://docs.ansible.com/ansible/playbooks_roles.html#role-dependencies)
@@ -17,7 +71,7 @@ By default this role does not depend on any external roles. If any such dependen
 
 - hosts: servers
   roles:
-     - role: wpnops.fluent-bit
+     - role: wpninfra.fluent-bit
 
 ## Testing
 
@@ -25,8 +79,11 @@ Please make sure your environment has [docker](https://www.docker.com) installed
 
 Role is tested against the following distributions (docker images):
 
+  * Ubuntu Bionic
   * Ubuntu Focal
   * Centos 7
+  * Centos 8
+  * Rocky Linux 8
 
 You can test the role directly from sources using command ` molecule test `
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,10 +15,10 @@ fluentbit_svc:
     listen_ip: 0.0.0.0
     listen_port: 2020
 
-fluentbit_filters: []
-fluentbit_inputs: []
-fluentbit_outputs: []
-fluentbit_parsers: []
+# fluentbit_filters: []
+# fluentbit_inputs: []
+# fluentbit_outputs: []
+# fluentbit_parsers: []
 
 
 fluentbit_apt_repo_focal: 'deb https://packages.fluentbit.io/ubuntu/focal focal main'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,4 +26,5 @@ fluentbit_outputs:
 fluentbit_parsers: []
 
 
-fluentbit_apt_repo: 'deb https://packages.fluentbit.io/ubuntu/focal focal main'
+fluentbit_apt_repo_focal: 'deb https://packages.fluentbit.io/ubuntu/focal focal main'
+fluentbit_apt_repo_bionic: 'deb https://packages.fluentbit.io/ubuntu/bionic bionic main'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,4 +15,15 @@ fluentbit_service:
     listen_ip: 0.0.0.0
     listen_port: 2020
 
+fluentbit_filters: []
+fluentbit_inputs:
+  - name: cpu
+    tag: cpu_default
+fluentbit_outputs:
+  - name: file
+    match: cpu_default
+    path: /dev/null
+fluentbit_parsers: []
+
+
 fluentbit_apt_repo: 'deb https://packages.fluentbit.io/ubuntu/focal focal main'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,22 +1,18 @@
 ---
 
-fluentbit_service_flush_seconds: 5
-fluentbit_service_daemon: false
-fluentbit_service_custom_parsers_files: []
-fluentbit_service_log_level: info
-fluentbit_service_enable_metrics: false
-fluentbit_service_metrics_listen_ip: 0.0.0.0
-fluentbit_service_metrics_listen_port: 2020
-
-fluentbit_inputs:
-  - name: tail
-    path: "/var/log/syslog"
-
-fluentbit_outputs:
-  - name: file
-    match: "*"
-    path: "/tmp/"
-
-fluentbit_additional_conf_files: []
+fluentbit_service:
+  flush_seconds: 5
+  daemon: false
+  log_level: info
+  ## optional
+  # log_file: ""
+  custom_parsers_files: []
+  custom_plugins_files: []
+  ## optional
+  # streams_file: ""
+  http_server:
+    state: false
+    listen_ip: 0.0.0.0
+    listen_port: 2020
 
 fluentbit_apt_repo: 'deb https://packages.fluentbit.io/ubuntu/focal focal main'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-fluentbit_service:
+fluentbit_svc:
   flush_seconds: 5
   daemon: false
   log_level: info
@@ -16,13 +16,8 @@ fluentbit_service:
     listen_port: 2020
 
 fluentbit_filters: []
-fluentbit_inputs:
-  - name: cpu
-    tag: cpu_default
-fluentbit_outputs:
-  - name: file
-    match: cpu_default
-    path: /dev/null
+fluentbit_inputs: []
+fluentbit_outputs: []
 fluentbit_parsers: []
 
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,10 +9,12 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - bionic
         - focal
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - fluentbit
     - fluent

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,11 +14,34 @@ platforms:
     cap_add: ['SYS_ADMIN', 'SETPCAP']
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: fluentbit_ubuntu_instance_1804
+    image: geerlingguy/docker-ubuntu1804-ansible
+    privileged: true
+    command: '/sbin/init'
+    cap_add: ['SYS_ADMIN', 'SETPCAP']
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - name: fluentbit_centos7_instance
     image: geerlingguy/docker-centos7-ansible
     privileged: true
     command: '/sbin/init'
     cap_add: ['SYS_ADMIN', 'SETPCAP']
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: fluentbit_rockylinux8_instance
+    image: geerlingguy/docker-rockylinux8-ansible
+    privileged: true
+    command: '/sbin/init'
+    cap_add: ['SYS_ADMIN', 'SETPCAP']
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  - name: fluentbit_centos8_instance
+    image: geerlingguy/docker-centos8-ansible
+    privileged: true
+    command: '/sbin/init'
+    cap_add: ['SYS_ADMIN', 'SETPCAP']
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,2 +1,0 @@
----
-- nephelaiio.plugins

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -5,22 +5,32 @@
     src: td-agent-bit.conf.j2
     dest: /etc/td-agent-bit/td-agent-bit.conf
     mode: 0644
+
+- name: Configure | td-agent-bit inputs
+  template:
+    src: 'inputs.conf.j2'
+    dest: '/etc/td-agent-bit/inputs.conf'
+    mode: 0644
+
+- name: Configure | td-agent-bit outputs
+  template:
+    src: 'outputs.conf.j2'
+    dest: '/etc/td-agent-bit/outputs.conf'
+    mode: 0644
   notify: Restart fluentbit service
 
-- name: Configure | td-agent-bit additional conf
+- name: Configure | td-agent-bit filters
   template:
-    src: '{{ item.template }}'
-    dest: '/etc/td-agent-bit/{{ item.name }}'
+    src: 'filters.conf.j2'
+    dest: '/etc/td-agent-bit/filters.conf'
     mode: 0644
-  with_items: '{{ fluentbit_additional_conf_files }}'
-  when: fluentbit_additional_conf_files | length >0
+  when: fluentbit_filters is defined
   notify: Restart fluentbit service
 
-- name: Configure | Source additional td-agent-bit parsers conf
+- name: Configure | td-agent-bit custom parsers
   template:
-    src: '{{ item.template }}'
-    dest: '/etc/td-agent-bit/{{ item.name }}'
+    src: 'parsers.conf.j2'
+    dest: '/etc/td-agent-bit/parsers.conf'
     mode: 0644
-  with_items: '{{ fluentbit_service_custom_parsers_files }}'
-  when: fluentbit_service_custom_parsers_files | length >0
+  when: fluentbit_custom_parsers is defined
   notify: Restart fluentbit service

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -5,9 +5,18 @@
     url: https://packages.fluentbit.io/fluentbit.key
     state: present
 
-- name: Install Debian | Add td-agent-bit repository
+- name: Install Debian | Add td-agent-bit repository for focal
   apt_repository:
-    repo: '{{ fluentbit_apt_repo }}'
+    repo: '{{ fluentbit_apt_repo_focal }}'
     state: present
     filename: td-agent-bit
     update_cache: true
+  when: ansible_facts['distribution_major_version'] == "20"
+
+- name: Install Debian | Add td-agent-bit repository for bionic
+  apt_repository:
+    repo: '{{ fluentbit_apt_repo_bionic }}'
+    state: present
+    filename: td-agent-bit
+    update_cache: true
+  when: ansible_facts['distribution_major_version'] == "18"

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Install Redhat | Add yum repository
+- name: Install Redhat | Add yum repository for Centos 7
   yum_repository:
     name: TD_Agent_Bit
     baseurl: http://packages.fluentbit.io/centos/7/$basearch/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- name: Debug family
+  debug: msg="{{ ansible_os_family }} - {{ ansible_distribution_major_version }}"
 
 - name: Install fluentbit
   include_tasks: 'install-{{ ansible_os_family }}.yml'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: Debug family
-  debug: msg="{{ ansible_os_family }} - {{ ansible_distribution_major_version }}"
-
 - name: Install fluentbit
   include_tasks: 'install-{{ ansible_os_family }}.yml'
   tags: ['install']

--- a/templates/filters.conf.j2
+++ b/templates/filters.conf.j2
@@ -1,0 +1,8 @@
+{% if fluentbit_filters is defined %}
+{% for filter in fluentbit_filters %}
+[FILTER]
+{% for key in filter %}
+    {{ key }} {{ filter[key] }}
+{% endfor %}
+{% endfor %}
+{% endif %}

--- a/templates/filters.conf.j2
+++ b/templates/filters.conf.j2
@@ -2,7 +2,7 @@
 {% for filter in fluentbit_filters %}
 [FILTER]
 {% for key in filter %}
-    {{ key }} {{ filter[key] }}
+    {{ key | regex_replace ('^[0-9]+__', '') }} {{ filter[key] }}
 {% endfor %}
 {% endfor %}
 {% endif %}

--- a/templates/inputs.conf.j2
+++ b/templates/inputs.conf.j2
@@ -2,7 +2,7 @@
 {% for input in fluentbit_inputs %}
 [INPUT]
 {% for key in input %}
-    {{ key }} {{ input[key] }}
+    {{ key | regex_replace ('^[0-9]+__', '') }} {{ input[key] }}
 {% endfor %}
 {% endfor %}
 {% else %}

--- a/templates/inputs.conf.j2
+++ b/templates/inputs.conf.j2
@@ -1,0 +1,12 @@
+{% if fluentbit_inputs is defined %}
+{% for input in fluentbit_inputs %}
+[INPUT]
+{% for key in input %}
+    {{ key }} {{ input[key] }}
+{% endfor %}
+{% endfor %}
+{% else %}
+[INPUT]
+    Name cpu
+    Tag cpu_default
+{% endif %}

--- a/templates/outputs.conf.j2
+++ b/templates/outputs.conf.j2
@@ -2,7 +2,7 @@
 {% for output in fluentbit_outputs %}
 [OUTPUT]
 {% for key in output %}
-    {{ key }} {{ output[key] }}
+    {{ key | regex_replace ('^[0-9]+__', '') }} {{ output[key] }}
 {% endfor %}
 {% endfor %}
 {% else %}

--- a/templates/outputs.conf.j2
+++ b/templates/outputs.conf.j2
@@ -1,0 +1,13 @@
+{% if fluentbit_outputs is defined %}
+{% for output in fluentbit_outputs %}
+[OUTPUT]
+{% for key in output %}
+    {{ key }} {{ output[key] }}
+{% endfor %}
+{% endfor %}
+{% else %}
+[OUTPUT]
+    Name file
+    Match cpu_default
+    Path /dev/null
+{% endif %}

--- a/templates/parsers.conf.j2
+++ b/templates/parsers.conf.j2
@@ -2,6 +2,7 @@
 {% for parser in fluentbit_custom_parsers %}
 [PARSER]
 {% for key in parser %}
-    {{ key }} {{ parser[key] }}
+    {{ key | regex_replace ('^[0-9]+__', '') }} {{ parser[key] }}
 {% endfor %}
 {% endfor %}
+{% endif %}

--- a/templates/parsers.conf.j2
+++ b/templates/parsers.conf.j2
@@ -1,0 +1,7 @@
+{% if fluentbit_custom_parsers is defined %}
+{% for parser in fluentbit_custom_parsers %}
+[PARSER]
+{% for key in parser %}
+    {{ key }} {{ parser[key] }}
+{% endfor %}
+{% endfor %}

--- a/templates/td-agent-bit.conf.j2
+++ b/templates/td-agent-bit.conf.j2
@@ -1,60 +1,42 @@
 # {{ansible_managed}}
 
 [SERVICE]
-    # Flush
-    # =====
-    # Set an interval of seconds before to flush records to a destination
-    Flush        {{ fluentbit_service_flush_seconds }}
 
-    # Daemon
-    # ======
-    # Instruct Fluent Bit to run in foreground or background mode.
-    Daemon       {{ (fluentbit_service_daemon | bool) | ternary('On', 'Off' ) }}
+    Flush {{ fluentbit_service.flush_seconds }}
 
-    # Log_Level
-    # =========
-    # Set the verbosity level of the service, values can be:
-    #
-    # - error
-    # - warning
-    # - info
-    # - debug
-    # - trace
-    #
-    # By default 'info' is set, that means it includes 'error' and 'warning'.
-    Log_Level    {{ fluentbit_service_log_level }}
+    Daemon {{ (fluentbit_service.daemon | bool) | ternary('On', 'Off' ) }}
 
-    # Parsers_File
-    # ============
-    # Specify an optional 'Parsers' configuration file
+    Log_Level {{ fluentbit_service.log_level }}
+
+{% if fluentbit_service.log_file is defined %}
+    Log_File {{  fluentbit_service.log_file }}
+{% endif %}
+
     Parsers_File parsers.conf
-{% for parsers_file in fluentbit_service_custom_parsers_files %}
+{% for parsers_file in fluentbit_service.custom_parsers_files %}
     Parsers_File {{ parsers_file.name }}
 {% endfor %}
 
     Plugins_File plugins.conf
-
-    # HTTP Server
-    # ===========
-    # Enable/Disable the built-in HTTP Server for metrics
-    HTTP_Server  {{ (fluentbit_service_enable_metrics | bool) | ternary('On', 'Off' ) }}
-    HTTP_Listen  {{ fluentbit_service_metrics_listen_ip }}
-    HTTP_Port    {{ fluentbit_service_metrics_listen_port }}
-
-{% for input in fluentbit_inputs %}
-[INPUT]
-{% for key in input %}
-    {{ key }} {{ input[key] }}
-{% endfor %}
+{% for plugins_file in fluentbit_service.custom_plugins_files %}
+    Pluins_File {{ plugins_file.name }}
 {% endfor %}
 
-{% for input in fluentbit_outputs %}
-[OUTPUT]
-{% for key in input %}
-    {{ key }} {{ input[key] }}
-{% endfor %}
-{% endfor %}
+{% if fluentbit_service.streams_file is defined %}
+    Streams_file {{ fluentbit_service.streams_file }}
+{% endif %}
 
-{% for additional_conf_file in fluentbit_additional_conf_files %}
-@INCLUDE {{ additional_conf_file.name }}
-{% endfor %}
+{% if fluentbit_service.http_server.state %}
+    HTTP_Server {{ (fluentbit_service.http_server.state | bool) | ternary('On', 'Off' ) }}
+    HTTP_Listen { fluentbit_service.http_server.listen_ip }}
+    HTTP_Port {{ fluentbit_service.http_server.listen_port }}
+{% endif %}
+
+@INCLUDE inputs.conf
+@INCLUDE outputs.conf
+{% if fluentbit_filters is defined %}
+@INCLUDE filters.conf
+{% endif %}
+{% if fluentbit_custom_parsers is defined %}
+@INCLUDE custom_parsers.conf
+{% endif %}

--- a/templates/td-agent-bit.conf.j2
+++ b/templates/td-agent-bit.conf.j2
@@ -2,34 +2,34 @@
 
 [SERVICE]
 
-    Flush {{ fluentbit_service.flush_seconds }}
+    Flush {{ fluentbit_svc.flush_seconds }}
 
-    Daemon {{ (fluentbit_service.daemon | bool) | ternary('On', 'Off' ) }}
+    Daemon {{ (fluentbit_svc.daemon | bool) | ternary('On', 'Off' ) }}
 
-    Log_Level {{ fluentbit_service.log_level }}
+    Log_Level {{ fluentbit_svc.log_level }}
 
-{% if fluentbit_service.log_file is defined %}
-    Log_File {{  fluentbit_service.log_file }}
+{% if fluentbit_svc.log_file is defined %}
+    Log_File {{  fluentbit_svc.log_file }}
 {% endif %}
 
     Parsers_File parsers.conf
-{% for parsers_file in fluentbit_service.custom_parsers_files %}
+{% for parsers_file in fluentbit_svc.custom_parsers_files %}
     Parsers_File {{ parsers_file.name }}
 {% endfor %}
 
     Plugins_File plugins.conf
-{% for plugins_file in fluentbit_service.custom_plugins_files %}
+{% for plugins_file in fluentbit_svc.custom_plugins_files %}
     Pluins_File {{ plugins_file.name }}
 {% endfor %}
 
-{% if fluentbit_service.streams_file is defined %}
-    Streams_file {{ fluentbit_service.streams_file }}
+{% if fluentbit_svc.streams_file is defined %}
+    Streams_file {{ fluentbit_svc.streams_file }}
 {% endif %}
 
-{% if fluentbit_service.http_server.state %}
-    HTTP_Server {{ (fluentbit_service.http_server.state | bool) | ternary('On', 'Off' ) }}
-    HTTP_Listen { fluentbit_service.http_server.listen_ip }}
-    HTTP_Port {{ fluentbit_service.http_server.listen_port }}
+{% if fluentbit_svc.http_server.state %}
+    HTTP_Server {{ (fluentbit_svc.http_server.state | bool) | ternary('On', 'Off' ) }}
+    HTTP_Listen { fluentbit_svc.http_server.listen_ip }}
+    HTTP_Port {{ fluentbit_svc.http_server.listen_port }}
 {% endif %}
 
 @INCLUDE inputs.conf


### PR DESCRIPTION
- Add 3 supported platforms(bionic, Centos8 & rockylinux8)
- Add extra configuration options
- Improve README
  
- Change file-based pipeline configuration to a variable-based pipeline configuration
  - In 1.x  input, parsers, filters, and outputs had to be j2 files. 2.x will change this behavior and now pipelines will be configured as such:
```
fluentbit_inputs:
  - name: cpu
    tag: cpu_default

fluentbit_outputs:
  - name: file
    match: cpu_default
    path: /dev/null
```
The above configuration will be rendered as:
```
[INPUT]
  Name cpu
  Tag cpu_default

[OUTPUT]
  Name file
  Match cpu_default
  Path /dev/null
```