### PR TITLE
[FIX] - Fix plugin parameter typo

### DIFF
--- a/templates/td-agent-bit.conf.j2
+++ b/templates/td-agent-bit.conf.j2
@@ -19,7 +19,7 @@
 
     Plugins_File plugins.conf
 {% for plugins_file in fluentbit_svc.custom_plugins_files %}
-    Pluins_File {{ plugins_file.name }}
+    Plugins_File {{ plugins_file.name }}
 {% endfor %}
 
 {% if fluentbit_svc.streams_file is defined %}


### PR DESCRIPTION
Hi @josesolis2201,

There is a parameter typo in templates/td-agent-bit.conf.j2 on line [22](https://github.com/wpnops/ansible-role-fluent-bit/blob/master/templates/td-agent-bit.conf.j2#L22).  I have fixed the incorrect plugin parameter name in this PR.