### PR TITLE
[Fix] - Removed custom_parser condition in td agent bit template

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please refer to [fluentbit's documentation](https://docs.fluentbit.io/manual/) f
 | fluentbit_filters                 | Dictionary with fluentbit filters                                                                                     | no       |         |
 | fluentbit_inputs                  | Dictionary with fluentbit inputs                                                                                      | no       |         |
 | fluentbit_outputs                 | Dictionary with fluentbit outputs                                                                                     | no       |         |
-| fluentbit_parsers                 | Dictionary with fluentbit custom written parsers                                                                      | no       |         |
+| fluentbit_custom_parsers          | Dictionary with fluentbit custom written parsers                                                                      | no       |         |
 
 **IF NO INPUTS OR OUTPUTS ARE DEFINED FLUENTBIT WILL INITIALIZE WITH THE FOLLOWING LOGGING STRUCTURE**
 ```

--- a/templates/td-agent-bit.conf.j2
+++ b/templates/td-agent-bit.conf.j2
@@ -37,6 +37,3 @@
 {% if fluentbit_filters is defined %}
 @INCLUDE filters.conf
 {% endif %}
-{% if fluentbit_custom_parsers is defined %}
-@INCLUDE parsers.conf
-{% endif %}

--- a/templates/td-agent-bit.conf.j2
+++ b/templates/td-agent-bit.conf.j2
@@ -38,5 +38,5 @@
 @INCLUDE filters.conf
 {% endif %}
 {% if fluentbit_custom_parsers is defined %}
-@INCLUDE custom_parsers.conf
+@INCLUDE parsers.conf
 {% endif %}


### PR DESCRIPTION
Hi @josesolis2201, the role is failing when adding custom parser config. I am having the below error in logs
` [Warning] [config] I cannot open /etc/td-agent-bit//custom_parsers.conf file `
` Error: Configuration file contains errors. Aborting `
` td-agent-bit.service: main process exited, code=exited, status=1/FAILURE`
` Unit td-agent-bit.service entered failed state.`

After removing [this](https://github.com/wpnops/ansible-role-fluent-bit/blob/master/templates/td-agent-bit.conf.j2#L40-L42), the td-agent-bit is working as expected for which I raised the PR. I also updated the parameter in readme.md based on this [template](https://github.com/wpnops/ansible-role-fluent-bit/blob/master/templates/parsers.conf.j2).